### PR TITLE
refactor: Update Domain Configuration in `page.tsx` for Analytics Validation

### DIFF
--- a/frontend/achievement-badge-system/app/page.tsx
+++ b/frontend/achievement-badge-system/app/page.tsx
@@ -106,7 +106,7 @@ function AnalyticsStatus() {
     if (typeof window !== 'undefined') {
       const checks = {
         projectIdSet: !!(window as any).reownProjectId,
-        domainConfigured: window.location.hostname === 'educational-sandbox.vercel.app' ||
+        domainConfigured: window.location.hostname === 'achievement-badge-system.vercel.app' ||
           window.location.hostname === 'localhost',
         appKitInstance: !!(window as any).appkit,
         analyticsEnabled: true // Assuming it's enabled in config


### PR DESCRIPTION
## Summary
This PR updates the **domain configuration check** within `page.tsx` to align with the correct production environment. The analytics validation logic now correctly references the deployed **`achievement-badge-system.vercel.app`** domain instead of the outdated `educational-sandbox.vercel.app`.

---

## Changes
### `frontend/achievement-badge-system/app/page.tsx`
- **Updated domain validation logic** in `AnalyticsStatus`:
  - Replaced `educational-sandbox.vercel.app` with `achievement-badge-system.vercel.app`.
  - Retained support for `localhost` to enable local development testing.
- Ensures that analytics configuration and status checks match the intended live deployment.

---

## Motivation
- **Fix incorrect domain reference**: The analytics check previously pointed to a deprecated sandbox environment.  
- **Enable production validation**: Ensures accurate detection of correct project configuration in the live app.  
- **Preserve local testing**: Maintains compatibility with `localhost` for developers working in non-production environments.  

---

## Next Steps
- Verify that analytics sessions initialize correctly in production on `achievement-badge-system.vercel.app`.  
- Add automated tests (Cypress/Playwright) to confirm analytics status check behavior across environments.  
- Update project documentation to reflect correct domain for production deployments.  

---
